### PR TITLE
Preserve the prototype when setting in an object

### DIFF
--- a/src/monolite.ts
+++ b/src/monolite.ts
@@ -45,7 +45,10 @@ export const setFromAccessorChain = <T, R>(root: R, accessors: string[]) =>
             newValue,
             ...currentNode.slice(Number(key) + 1),
           ]
-          : Object.assign({}, currentNode, { [key]: newValue })
+          : Object.assign(
+            Object.create(Object.getPrototypeOf(currentNode)),
+            currentNode, { [key]: newValue }
+          )
     }
   }
 

--- a/src/tests/set.spec.ts
+++ b/src/tests/set.spec.ts
@@ -75,3 +75,19 @@ it('does not transform arrays to objects', () => {
   expect(updatedTree2.subjects[0].name).toBe('John')
   expect(updatedTree2.subjects[1].name).toBe('Bobby')
 })
+
+it('preserves the prototype of the tree', () => {
+  const tree = Object.assign(Object.create({
+    a: 1, b: { c: 2 }
+  }), {
+    d: { e: 3 }
+  })
+
+  const updatedTree = set(tree, _ => _.d.e)(4)
+  expect(updatedTree.a).toBe(1)
+  expect(typeof updatedTree.b).toBe('object')
+  expect(updatedTree.b).toBe(tree.b)
+
+  const updatedTree2 = set(tree, _ => _.d.e)(3)
+  expect(updatedTree2).toBe(tree)
+})


### PR DESCRIPTION
Fixes #12.