### PR TITLE
Custom assign function

### DIFF
--- a/src/assign.ts
+++ b/src/assign.ts
@@ -1,0 +1,86 @@
+
+      /*#######.
+     ########",#:
+   #########',##".
+  ##'##'## .##',##.
+   ## ## ## # ##",#.
+    ## ## ## ## ##'
+     ## ## ## :##
+      ## ## ##*/
+
+const hasOwnProperty = Object.prototype.hasOwnProperty
+
+export function __assign<T extends object, A extends object>(
+  target: T,
+  a: A
+): T & A
+
+export function __assign<
+  T extends object,
+  A extends object,
+  B extends object
+>(target: T, a: A, b: B): T & A & B
+
+export function __assign<
+  T extends object,
+  A extends object,
+  B extends object,
+  C extends object
+>(target: T, a: A, b: B, c: C): T & A & B & C
+
+export function __assign<
+  T extends object,
+  A extends object,
+  B extends object,
+  C extends object,
+  D extends object
+>(target: T, a: A, b: B, c: C, d: D): T & A & B & C & D
+
+export function __assign<
+  T extends object,
+  A extends object,
+  B extends object,
+  C extends object,
+  D extends object,
+  E extends object
+>(target: T, a: A, b: B, c: C, d: D, e: E): T & A & B & C & D & E
+
+export function __assign<
+  T extends object,
+  A extends object,
+  B extends object,
+  C extends object,
+  D extends object,
+  E extends object,
+  F extends object
+>(
+  target: T,
+  a: A,
+  b: B,
+  c: C,
+  d: D,
+  e: E,
+  f: F
+): T & A & B & C & D & E & F
+
+/**
+ *
+ */
+export function __assign<T extends object>(
+  target: T,
+  ...sources: any[]
+) {
+  const to = Object(target)
+
+  for (const source of sources) {
+    for (const key in source) {
+      if (hasOwnProperty.call(source, key)) {
+        to[key] = source[key]
+      }
+    }
+  }
+  return to
+}
+
+export const assign =
+  typeof Object.assign === 'function' ? Object.assign : __assign

--- a/src/deepEqual.ts
+++ b/src/deepEqual.ts
@@ -38,7 +38,7 @@ const objectEqual = (a: any, b: any) => {
   return true
 }
 
-const deepEqual = (a: any, b: any) => {
+export const deepEqual = (a: any, b: any) => {
   if (a === b) {
     return true
   }
@@ -56,5 +56,3 @@ const deepEqual = (a: any, b: any) => {
   }
   return a.valueOf() === b.valueOf()
 }
-
-export default deepEqual

--- a/src/monolite.ts
+++ b/src/monolite.ts
@@ -8,7 +8,8 @@
      ## ## ## :##
       ## ## ##*/
 
-import deepEqual from './deepEqual'
+import { assign } from './assign'
+import { deepEqual } from './deepEqual'
 import { getAccessorChain } from './accessorChain'
 
 /**
@@ -44,7 +45,7 @@ export const setFromAccessorChain = <T, R>(
             newValue,
             ...currentNode.slice(Number(key) + 1)
           ]
-        : Object.assign(
+        : assign(
             Object.create(Object.getPrototypeOf(currentNode)),
             currentNode,
             { [key]: newValue }

--- a/src/tests/assign.spec.ts
+++ b/src/tests/assign.spec.ts
@@ -1,0 +1,55 @@
+
+      /*#######.
+     ########",#:
+   #########',##".
+  ##'##'## .##',##.
+   ## ## ## # ##",#.
+    ## ## ## ## ##'
+     ## ## ## :##
+      ## ## ##*/
+
+import { __assign as assign } from '../assign'
+
+it('copies all properties in a target object', () => {
+  const source = { a: 42, b: 'Hello' }
+  const clone = assign({}, source)
+
+  expect(clone).not.toBe(source)
+  expect(clone).toEqual(source)
+})
+
+it('only copies own properties', () => {
+  const prototype = { a: 42 }
+  const source = Object.create(prototype, {
+    b: { enumerable: true, value: 'Hello' }
+  })
+
+  const clone = assign({}, source)
+
+  expect(source.a).toEqual(42)
+  expect(clone).not.toHaveProperty('a')
+  expect(source.b).toEqual(clone.b)
+})
+
+it('can copy multiple sources', () => {
+  const source1 = { a: 42 }
+  const source2 = { b: 'Hello' }
+  const source3 = { c: { hello: 'World' } }
+
+  const mixin = assign({}, source1, source2, source3)
+
+  expect(mixin.a).toEqual(42)
+  expect(mixin.b).toEqual('Hello')
+  expect(mixin.c).toEqual({ hello: 'World' })
+})
+
+it('can mutate target object', () => {
+  const target = { a: 42, b: 'Bonjour' }
+  const source = { a: 13, c: 'Hello' }
+
+  assign(target, source)
+
+  expect(target.a).toEqual(13)
+  expect(target.b).toEqual('Bonjour')
+  expect((target as any).c).toEqual('Hello')
+})

--- a/src/tests/deepEqual.spec.ts
+++ b/src/tests/deepEqual.spec.ts
@@ -8,7 +8,7 @@
      ## ## ## :##
       ## ## ##*/
 
-import deepEqual from '../deepEqual'
+import { deepEqual } from '../deepEqual'
 
 it('handles primitive types', () => {
   expect(deepEqual(1, 1)).toBe(true)

--- a/src/tests/set.spec.ts
+++ b/src/tests/set.spec.ts
@@ -9,6 +9,7 @@
       ## ## ##*/
 
 import { set } from '../monolite'
+import { assign } from '../assign'
 
 it('should accept accessor chains', () => {
   const tree = { b: { c: true }, d: { e: true } }
@@ -74,7 +75,7 @@ it('does not transform arrays to objects', () => {
 })
 
 it('preserves the prototype of the tree', () => {
-  const tree = Object.assign(
+  const tree = assign(
     Object.create({
       a: 1,
       b: { c: 2 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "es6",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "target": "es5",
+    "lib": ["es5", "es2015.core"],
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "declaration": true,


### PR DESCRIPTION
Remove direct usage of `Object.assign`, not compatible with ES5.