### PR TITLE
Update package.json to include the repository 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "test": "jest",
     "build": "webpack"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kube/monolite.git"
+  },
   "authors": [
     {
       "name": "Chris Feijoo",

--- a/workspaces/babel-plugin-monolite/package.json
+++ b/workspaces/babel-plugin-monolite/package.json
@@ -7,6 +7,11 @@
     "test": "jest",
     "build": "webpack"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kube/monolite.git",
+    "directory": "workspaces/babel-plugin-monolite"
+  },
   "authors": [
     {
       "name": "Chris Feijoo",

--- a/workspaces/monolite/package.json
+++ b/workspaces/monolite/package.json
@@ -8,6 +8,11 @@
     "test": "jest",
     "build": "webpack"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kube/monolite.git",
+    "directory": "workspaces/monolite"
+  },
   "authors": [
     {
       "name": "Chris Feijoo",

--- a/workspaces/test-electron/package.json
+++ b/workspaces/test-electron/package.json
@@ -4,6 +4,11 @@
   "scripts": {
     "test": "electron ./test.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kube/monolite.git",
+    "directory": "workspaces/test-electron"
+  },
   "devDependencies": {
     "electron": "^8.2.0"
   }


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• monolite-workspaces
• babel-plugin-monolite
• monolite
• test-electron